### PR TITLE
Fix for unset default content type in response header

### DIFF
--- a/lib/insights-rbac-api-client/api_client.rb
+++ b/lib/insights-rbac-api-client/api_client.rb
@@ -184,7 +184,7 @@ module RBACApiClient
       return body if return_type == 'String'
 
       # ensuring a default content type
-      content_type = response.headers['Content-Type'] || 'application/json'
+      content_type = response.headers&.dig('Content-Type') || 'application/json'
 
       fail "Content-Type is not supported: #{content_type}" unless json_mime?(content_type)
 


### PR DESCRIPTION
solves:
```
  NoMethodError:
    undefined method `[]' for nil:NilClass
  # ./bundle/ruby/3.0.0/gems/insights-rbac-api-client-1.0.0/lib/insights-rbac-api-client/api_client.rb:187:in `deserialize'
  # ./bundle/ruby/3.0.0/gems/insights-rbac-api-client-1.0.0/lib/insights-rbac-api-client/api_client.rb:72:in `call_api'
  # ./bundle/ruby/3.0.0/gems/insights-rbac-api-client-1.0.0/lib/insights-rbac-api-client/api/access_api.rb:99:in `get_principal_access_with_http_info'
  # ./bundle/ruby/3.0.0/gems/insights-rbac-api-client-1.0.0/lib/insights-rbac-api-client/api/access_api.rb:31:in `get_principal_access'
```

Experiencing in https://github.com/RedHatInsights/compliance-backend/pull/1225 (see https://ci.int.devshift.net/job/RedHatInsights-compliance-backend-pr-check/1428/console)